### PR TITLE
rename recipe section, add doc str

### DIFF
--- a/src/rezup/_version.py
+++ b/src/rezup/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 def package_info():

--- a/src/rezup/container.py
+++ b/src/rezup/container.py
@@ -166,11 +166,32 @@ class Revision:
         return revision
 
     def _install(self, recipe):
+        """
+        Example recipe file `rezup.toml`
+
+            description = "My rez setup"
+
+            [rez]
+            name = "rez"
+            url = "rez>=2.83"
+
+            [[extension]]
+            name = "foo"
+            url = "~/dev/foo"
+            edit = true
+
+            [[extension]]
+            name = "bar"
+            url = "git+git://github.com/get-bar/bar"
+            isolation = true
+            python = 2.7
+
+        """
         tools = []
         installer = Installer(self)
 
         tools.append(Tool(recipe["rez"]))
-        for data in recipe.get("extensions", []):
+        for data in recipe.get("extension", []):
             tools.append(Tool(data))
 
         for tool in tools:

--- a/src/rezup/rezup.toml
+++ b/src/rezup/rezup.toml
@@ -5,17 +5,3 @@ schema = "rezup-recipe:1.0"
 [rez]
 name = "rez"
 url = "rez>=2.83"
-
-# [[extension]]
-# name = "foo"
-# url = "~/dev/foo"
-# edit = true
-
-# [[extension]]
-# name = "bar"
-# url = "git+git://github.com/get-bar/bar"
-# isolation = true
-# python = 2.7
-
-# [env]
-# MY_ENV_VAR = 1


### PR DESCRIPTION
There was a typo in #4 that the section name for installing extensions (array of object) in recipe toml file should be `extension`, not `extensions` (mind the *s*).
