### PR TITLE
Fix #22 : Shell detection failure cause subprocess hang

### DIFF
--- a/src/rezup/_version.py
+++ b/src/rezup/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 
 def package_info():

--- a/src/rezup/launch/shell.py
+++ b/src/rezup/launch/shell.py
@@ -36,18 +36,25 @@ def get_current_shell():
 
 def provide_default():
     if os.name == "posix":
-        return os.environ["SHELL"]
+        shell = os.environ["SHELL"]
     elif os.name == "nt":
-        return os.environ["COMSPEC"]
-    raise NotImplementedError(f"OS {os.name!r} support not available")
+        shell = os.environ["COMSPEC"]
+    else:
+        raise NotImplementedError(f"OS {os.name!r} support not available")
+
+    shell, ext = os.path.splitext(os.path.basename(shell))
+    shell = shell.lower()
+
+    return shell
 
 
 def get_launch_cmd(name, launch_dir, block=True):
-    launch_script = None
     for script, supported_shells in LAUNCH_SCRIPTS.items():
         if name in supported_shells:
             launch_script = str(launch_dir / script)
             break
+    else:
+        raise Exception("No matching launch script for current shell: %s" % name)
 
     if name == "cmd":
         command = [name]
@@ -64,9 +71,8 @@ def get_launch_cmd(name, launch_dir, block=True):
     else:
         command = [name]
 
-    if launch_script:
-        command.append(launch_script)
-
+    # Must have launch script
+    command.append(launch_script)
     return command
 
 


### PR DESCRIPTION
This close #22.

In `rezup` we use `shellingham` to detect shell type so to launch sub-shell. However the shell detection may fail in some scenario, e.g. in PyCharm's Python Console.

When that happens, default shell will be provided from env var `"COMSPEC"` (in Windows), which is the abs location of `cmd.exe` and the launch script mapping table only use lower case base name e.g. `cmd`. Hence, no launch script is used and ends up with a sub-shell waiting for input.

This PR ensures launch script is provided, and raise error if not.