### PR TITLE
Fix #25 and loose rezup-api version requires

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -18,6 +18,8 @@ project_urls =
 [options]
 zip_safe = true
 python_requires = >=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+install_requires =
+    rezup-api>=1.9,<2
 packages = find:
 
 [options.entry_points]

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -9,5 +9,4 @@ __version__ = g["__version__"]
 
 setup(
     version=__version__,
-    install_requires=["rezup-api==" + __version__]
 )

--- a/src/rezup/_version.py
+++ b/src/rezup/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 
 def package_info():

--- a/src/rezup/upgrade.py
+++ b/src/rezup/upgrade.py
@@ -104,12 +104,18 @@ def upgrade():
 
 
 def restart():
+    args = sys.argv[:]
+    # ensure first argument is executable
+    #   (could be __main__.py if rezup is called as module)
+    if sys.argv[0].endswith("__main__.py"):
+        args = [sys.executable, "-m", "rezup"] + args[1:]
+
     if sys.platform == "win32":
         sys.exit(
-            subprocess.run(sys.argv).returncode
+            subprocess.run(args).returncode
         )
     else:
-        os.execv(sys.argv[0], sys.argv)
+        os.execv(args[0], args)
 
 
 def update_record_file():


### PR DESCRIPTION
This close #25, and try to get rid of following error when upgrading
```
rezup 1.8.0 requires rezup-api==1.8.0, but you have rezup-api 1.9.0 which is incompatible.
```