### PR TITLE
Set version as '0.0.0' if not installed

### DIFF
--- a/src/rezup/__init__.py
+++ b/src/rezup/__init__.py
@@ -2,7 +2,7 @@
 try:
     from ._version import __version__
 except ImportError:
-    __version__ = None  # not installed
+    __version__ = "0.0.0"  # not installed
 
 from .container import Container, Revision, iter_containers
 from .recipe import ContainerRecipe
@@ -14,7 +14,7 @@ def get_rezup_version():
     import sys
     return "{name} {ver} from {lib} (python {x}.{y})".format(
         name="rezup",
-        ver=__version__ or "(not installed)",
+        ver=__version__,
         lib=__path__[0],
         x=sys.version_info.major,
         y=sys.version_info.minor,


### PR DESCRIPTION
## Problem
After PR #43 , the `_version.py` may not exists when installing `rezup` from source or in edit mode. In that case, the `__version__` would be `None` and leads to not able to access any Rez production bin scripts.

Because, when the `__version__` is `None`, the revision metadata's value of `rezup_version` is also `None`, cause the method `Revision.production_bin_dirs()` returns `rezup-1.x` styled production bin path even that revision is actually been created by `rezup-2.x`.

## Fix
So the `__version__` must have a value and I find `0.0.0` is a good enough for this.