### PR TITLE
Able to force using local container

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Recipe file name should embed container name (if not default container) so that 
 |REZUP_DEFAULT_SHELL|Specify shell to use. See [launch/README](src/rezup/launch/README.md#shell-detection).|
 |REZUP_PROMPT|For customizing shell prompt, optional. See [launch/README](src/rezup/launch/README.md#shell-prompt).|
 |REZUP_CONTAINER|Auto set, for customizing shell prompt. See [launch/README](src/rezup/launch/README.md#shell-prompt).|
+|REZUP_USING_REMOTE|Auto set, indicating where the container is sourced from.|
 |REZUP_TEST_KEEP_TMP|Preserve temp dirs in tests.|
 
 

--- a/src/rezup/cli.py
+++ b/src/rezup/cli.py
@@ -127,7 +127,7 @@ class RezupCLI:
         self._compose_job(do)
         self._wait = not just
 
-        container = Container.create(name, force_local=local)
+        container = Container(name, force_local=local)
         revision = container.get_latest_revision()
 
         if revision:

--- a/src/rezup/cli.py
+++ b/src/rezup/cli.py
@@ -94,7 +94,7 @@ class RezupCLI:
 
                 self._job = " ".join(args)
 
-    def use(self, name=_default_cname, just=False, do=None):
+    def use(self, name=_default_cname, local=False, just=False, do=None):
         """Step into a container. Run `rezup use -h` for help
 
         This will open a sub-shell which has Rez venv ready to use. Simply
@@ -108,6 +108,9 @@ class RezupCLI:
             - use container 'foo'
             $ rezup use foo
 
+            - ignore remote and only use local container
+            $ rezup use foo --local
+
             - use foo and do job (non-interactive session)
             $ rezup use foo --do {script.bat or "quoted command"}
 
@@ -116,6 +119,7 @@ class RezupCLI:
 
         Args:
             name (str): container name
+            local (bool): ignore remote and use local container
             just (bool): not waiting --do script/command to complete, just do
             do (str): run a shell script or command and exit
 
@@ -123,7 +127,7 @@ class RezupCLI:
         self._compose_job(do)
         self._wait = not just
 
-        container = Container(name)
+        container = Container.create(name, force_local=local)
         revision = container.get_latest_revision()
 
         if revision:

--- a/src/rezup/container.py
+++ b/src/rezup/container.py
@@ -429,6 +429,7 @@ class Revision:
 
         env.update({
             "REZUP_CONTAINER": self._container.name(),
+            "REZUP_USING_REMOTE": "yes" if self._is_pulled else "",
         })
 
         return env

--- a/src/rezup/container.py
+++ b/src/rezup/container.py
@@ -262,6 +262,7 @@ class Revision:
         self._metadata = None
         self._recipe = RevisionRecipe(self)
         self._metadata_path = self._path / "revision.json"
+        self._is_pulled = False
 
     def __repr__(self):
         return "%s(valid=%d, ready=%d, remote=%d, path=%r)" % (
@@ -479,6 +480,9 @@ class Revision:
             revision = Revision(container=local, dirname=self._dirname)
             revision._write(pulling=self)
 
+        if revision is not None:
+            revision._is_pulled = True
+
         return revision
 
     def spawn_shell(self, command=None):
@@ -523,8 +527,10 @@ class Revision:
             else:
                 # interactive shell
                 block = True
+                _con_name = self._container.name()
+                _con_from = "remote" if self._is_pulled else "local"
                 replacement["__REZUP_SHELL__"] = shell_exec
-                prompt = "rezup (%s) " % self._container.name()
+                prompt = "rezup (%s/%s) " % (_con_name, _con_from)
                 prompt = shell.format_prompt_code(prompt, shell_name)
                 environment.update({
                     "REZUP_PROMPT": os.getenv("REZUP_PROMPT", prompt),


### PR DESCRIPTION
* add `rezup use --local` flag, so the remote container can be ignored
* new env var `REZUP_USING_REMOTE`, the value would be empty if the container is sourced from local, else `"yes"`.