### PR TITLE
patch entry-point for edit-in-production

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -225,3 +225,15 @@ This works by creating a `.pth` file that contains the absolute path of shared l
 
 
 ## Production Install
+
+Rezup installs Rez and the tooling by following Rez installation script's "production-install" schema :
+
+1. Install Rez in a fresh Python virtual environment.
+2. Command line entry-points (bin tools) are all patched with Python interpreter flag `-E`.
+3. All bin tools get stored in a sub-directory of regular Python bin tools install location (`{venv}/bin/rez` or `{venv}/Scripts/rez` on Windows).
+
+See Rez Wiki [Why Not Pip For Production?](https://github.com/nerdvegas/rez/wiki/Installation#why-not-pip-for-production) section for a bit more detail.
+
+But if Rez gets installed in *edit-mode*, it will fail to compute the location of those production-installed bin tools and not able to provide features like nesting resolved contexts or running some specific rez tests.
+
+Rezup covers this situation by using custom entry-point script. If Rez is going to be installed in edit-mode, all bin tools will be generated with the custom script, which will pre-cache the location of bin tools when the session starts if, the environment variable `REZUP_EDIT_IN_PRODUCTION` exists and is not empty.

--- a/docs/container.md
+++ b/docs/container.md
@@ -237,3 +237,15 @@ See Rez Wiki [Why Not Pip For Production?](https://github.com/nerdvegas/rez/wiki
 But if Rez gets installed in *edit-mode*, it will fail to compute the location of those production-installed bin tools and not able to provide features like nesting resolved contexts or running some specific rez tests.
 
 Rezup covers this situation by using custom entry-point script. If Rez is going to be installed in edit-mode, all bin tools will be generated with the custom script, which will pre-cache the location of bin tools when the session starts if, the environment variable `REZUP_EDIT_IN_PRODUCTION` exists and is not empty (see [davidlatwe/rezup#56](https://github.com/davidlatwe/rezup/pull/56) for implementation detail).
+
+You may put that env var in e.g. `rezup.dev.toml` like this:
+
+```toml
+[env]
+REZUP_EDIT_IN_PRODUCTION = "1"
+
+[rez]
+name = "rez"
+url = "/path/to/source/rez"
+edit = true
+```

--- a/docs/container.md
+++ b/docs/container.md
@@ -236,4 +236,4 @@ See Rez Wiki [Why Not Pip For Production?](https://github.com/nerdvegas/rez/wiki
 
 But if Rez gets installed in *edit-mode*, it will fail to compute the location of those production-installed bin tools and not able to provide features like nesting resolved contexts or running some specific rez tests.
 
-Rezup covers this situation by using custom entry-point script. If Rez is going to be installed in edit-mode, all bin tools will be generated with the custom script, which will pre-cache the location of bin tools when the session starts if, the environment variable `REZUP_EDIT_IN_PRODUCTION` exists and is not empty.
+Rezup covers this situation by using custom entry-point script. If Rez is going to be installed in edit-mode, all bin tools will be generated with the custom script, which will pre-cache the location of bin tools when the session starts if, the environment variable `REZUP_EDIT_IN_PRODUCTION` exists and is not empty (see [davidlatwe/rezup#56](https://github.com/davidlatwe/rezup/pull/56) for implementation detail).

--- a/docs/container.md
+++ b/docs/container.md
@@ -222,3 +222,6 @@ requires = [
 For faster deploy, dependency packages can be installed in here, and will be shared across all revisions in one container (all revisions that use same `name` of shared lib).
 
 This works by creating a `.pth` file that contains the absolute path of shared lib in Rez venv and only that venv. So this will not be shared with the extension that has `isolation` set to true.
+
+
+## Production Install

--- a/docs/environ.md
+++ b/docs/environ.md
@@ -9,4 +9,5 @@
 |REZUP_PROMPT|For customizing shell prompt, optional. See [Command](../command#shell-prompt).|
 |REZUP_CONTAINER|Auto set, for customizing shell prompt. See [Command](../command#shell-prompt).|
 |REZUP_USING_REMOTE|Auto set, indicating where the container was sourced from.|
+|REZUP_EDIT_IN_PRODUCTION|Enable production privilege for Rez that was installed in edit mode.|
 |REZUP_TEST_KEEP_TMP|Preserve temp dirs in tests.|


### PR DESCRIPTION
This change relates to https://github.com/davidlatwe/rezup/pull/41/commits/9417aea4649a5399873f2b17094fbfd6ab7ef8d3.

In previous approach for maintaining Rez production-install features in edit-mode, requires code change in Rez itself, which isn't ideal. This implementation only requires one env var and custom entry point script.

The idea is to pre-cache the `rez.system.System` singleton's cacheable property `rez_bin_path`, right before the tool gets launched.

Rez computes the `rez_bin_path` by the relative path from `rez.__path__[0]` to those rez bin tools under production installation venv layout. But if Rez was installed in edit-mode, `rez.__path__[0]` is pointing to the location of source code which is outside of venv hence not able to compute and provide rez bin tool in a nested context (running `rez-env` in a resolved context session).

But if we could just give it the answer before it trys to compute, the problem solved. Therefore, we inject the full path of those rez bin tools into the executable scripts and it will self-cache `rez_bin_path` while being launched.

Note that only when Rez itself is being installed in edit-mode will use that custom script, other extensions won't trigger this behavior. Also, the pre-cache will only happen if the env var `REZUP_EDIT_IN_PRODUCTION` is set and is not empty.

I really love to work with Rez in edit-mode while keeping production-install features.
