### PR TITLE
fix turning env keys to lowercase

### DIFF
--- a/src/rezup/container.py
+++ b/src/rezup/container.py
@@ -568,8 +568,11 @@ class Revision:
         recipe_env = recipe.get("env")
         if recipe_env:
             stream = StringIO()
-            parsed_recipe_env = ConfigParser(recipe_env)
-            parsed_recipe_env.write(stream)
+
+            _parser = ConfigParser()
+            _parser.optionxform = str  # to prevent turning keys into lowercase
+            _parser.read_dict({"env": recipe_env})
+            _parser.write(stream)
 
             stream.seek(0)  # must reset buffer
             env.update(load_env(stream=stream))


### PR DESCRIPTION
### Problem

The env vars in section 'env' of recipe are firstly parsed by `ConfigParser` then read by `dotenv`. I didn't know the fact that `ConfigParser` by default turns keys into lowercase, which seems to be a problem for Unix machine (e.g. my macbook) to take those lowercase envs. (I mostly on Windows)

### Fix

Set `ConfigParser.optionxform = str` fixed the problem.

Reference:
https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.optionxform
https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.BOOLEAN_STATES (next section)
